### PR TITLE
feat: enhance Install method to support labels and annotations for Helm releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	k8s.io/kubectl v0.34.1
 	kubevirt.io/api v1.6.1
 	kubevirt.io/containerized-data-importer-api v1.63.0
+	sigs.k8s.io/kustomize/kyaml v0.20.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -243,7 +244,6 @@ require (
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )

--- a/internal/core/application_release.go
+++ b/internal/core/application_release.go
@@ -19,7 +19,7 @@ type Release = release.Release
 type ReleaseRepo interface {
 	List(config *rest.Config, namespace string) ([]release.Release, error)
 	Get(restConfig *rest.Config, namespace, name string) (*release.Release, error)
-	Install(config *rest.Config, namespace, name string, dryRun bool, chartRef string, values map[string]any) (*release.Release, error)
+	Install(config *rest.Config, namespace, name string, dryRun bool, chartRef string, labels, annotations map[string]string, values map[string]any) (*release.Release, error)
 	Uninstall(config *rest.Config, namespace, name string, dryRun bool) (*release.Release, error)
 	Upgrade(config *rest.Config, namespace, name string, dryRun bool, chartRef string, values map[string]any) (*release.Release, error)
 	Rollback(config *rest.Config, namespace, name string, dryRun bool) error
@@ -44,7 +44,20 @@ func (uc *ApplicationUseCase) CreateRelease(ctx context.Context, uuid, facility,
 	if err != nil {
 		return nil, err
 	}
-	return uc.release.Install(config, namespace, getReleaseName(name), dryRun, chartRef, values)
+
+	// labels
+	labels := map[string]string{
+		ApplicationReleaseNameLabel: name,
+	}
+	if strings.Contains(chartRef, "llm-d-incubation/llm-d-modelservice") {
+		labels[ApplicationReleaseLLMDModelNameLabel] = valuesMap["modelArtifacts.name"]
+	}
+
+	// annotations
+	annotations := map[string]string{
+		ApplicationReleaseChartRefAnnotation: chartRef,
+	}
+	return uc.release.Install(config, namespace, getReleaseName(name), dryRun, chartRef, labels, annotations, values)
 }
 
 func (uc *ApplicationUseCase) UpdateRelease(ctx context.Context, uuid, facility, namespace, name string, dryRun bool, chartRef, valuesYAML string) (*Release, error) {

--- a/internal/core/const.go
+++ b/internal/core/const.go
@@ -1,10 +1,12 @@
 package core
 
 const (
-	LabelDomain                 = "otterscale.com"
-	DataVolumeBootImageLabel    = "otterscale.com/data-volume.boot-image"
-	VirtualMachineNameLabel     = "otterscale.com/virtual-machine.name"
-	ApplicationReleaseNameLabel = "otterscale.com/application-release.name"
+	LabelDomain                          = "otterscale.com"
+	DataVolumeBootImageLabel             = "otterscale.com/data-volume.boot-image"
+	VirtualMachineNameLabel              = "otterscale.com/virtual-machine.name"
+	ApplicationReleaseNameLabel          = "otterscale.com/application-release.name"
+	ApplicationReleaseLLMDModelNameLabel = "otterscale.com/application-release.llmd-model-name"
+	ApplicationReleaseChartRefAnnotation = "otterscale.com/application-release.chart-ref"
 )
 
 const BuiltInMachineTagComment = "built-in"

--- a/internal/data/kube/helm_release.go
+++ b/internal/data/kube/helm_release.go
@@ -1,12 +1,15 @@
 package kube
 
 import (
+	"bytes"
 	"fmt"
 	"log/slog"
+	"maps"
 
 	"connectrpc.com/connect"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/kustomize/kyaml/kio"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -17,6 +20,47 @@ import (
 
 	oscore "github.com/otterscale/otterscale/internal/core"
 )
+
+type postRenderer struct {
+	extraLabels      map[string]string
+	extraAnnotations map[string]string
+}
+
+func newPostRenderer(extraLabels, extraAnnotaions map[string]string) *postRenderer {
+	return &postRenderer{
+		extraLabels:      extraLabels,
+		extraAnnotations: extraAnnotaions,
+	}
+}
+
+func (p *postRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	if len(p.extraLabels) == 0 {
+		return renderedManifests, nil
+	}
+	nodes, err := kio.FromBytes(renderedManifests.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes {
+		// labels
+		labels := node.GetLabels()
+		maps.Copy(labels, p.extraLabels)
+		if err := node.SetLabels(labels); err != nil {
+			return nil, err
+		}
+		// annotations
+		annotations := node.GetAnnotations()
+		maps.Copy(annotations, p.extraAnnotations)
+		if err := node.SetAnnotations(annotations); err != nil {
+			return nil, err
+		}
+	}
+	str, err := kio.StringAll(nodes)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewBufferString(str), nil
+}
 
 type helmRelease struct {
 	kube *Kube
@@ -61,7 +105,7 @@ func (r *helmRelease) Get(restConfig *rest.Config, namespace, name string) (*rel
 	return client.Run(name)
 }
 
-func (r *helmRelease) Install(restConfig *rest.Config, namespace, name string, dryRun bool, chartRef string, values map[string]any) (*release.Release, error) {
+func (r *helmRelease) Install(restConfig *rest.Config, namespace, name string, dryRun bool, chartRef string, labels, annotations map[string]string, values map[string]any) (*release.Release, error) {
 	if !action.ValidName.MatchString(name) {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid release name %q", name))
 	}
@@ -76,10 +120,7 @@ func (r *helmRelease) Install(restConfig *rest.Config, namespace, name string, d
 	client.Namespace = namespace
 	client.DryRun = dryRun
 	client.ReleaseName = name
-	client.Labels = map[string]string{
-		oscore.ApplicationReleaseNameLabel: name,
-		// "app.otterscale.com/chart-ref":    chartRef, // TODO: invalid label format
-	}
+	client.PostRenderer = newPostRenderer(labels, annotations)
 
 	chartPath, err := client.LocateChart(chartRef, r.kube.envSettings)
 	if err != nil {

--- a/internal/data/kube/helm_release_test.go
+++ b/internal/data/kube/helm_release_test.go
@@ -69,7 +69,7 @@ func TestHelmRelease_Install_InvalidName(t *testing.T) {
 	rl, _ := NewHelmRelease(k)
 
 	restCfg := &rest.Config{Host: "https://example.invalid"}
-	_, err := rl.Install(restCfg, "default", "bad name", false, "any/chart", nil)
+	_, err := rl.Install(restCfg, "default", "bad name", false, "any/chart", nil, nil, nil)
 
 	if err == nil {
 		t.Fatal("expected error for invalid release name, got nil")
@@ -87,7 +87,7 @@ func TestHelmRelease_Install_ChartNotFound(t *testing.T) {
 	rl, _ := NewHelmRelease(k)
 
 	restCfg := &rest.Config{Host: "https://example.invalid"}
-	_, err := rl.Install(restCfg, "default", "valid-name", false, "nonexistent/chart", nil)
+	_, err := rl.Install(restCfg, "default", "valid-name", false, "nonexistent/chart", nil, nil, nil)
 
 	if err == nil {
 		t.Fatal("expected error when chart cannot be located, got nil")
@@ -160,7 +160,7 @@ func TestHelmRelease_EdgeCases_NilKube(t *testing.T) {
 		cfg := &rest.Config{Host: "https://example.invalid"}
 
 		_, _ = h.List(cfg, "default")
-		_, _ = h.Install(cfg, "default", "name", false, "chart/ref", nil)
+		_, _ = h.Install(cfg, "default", "name", false, "chart/ref", nil, nil, nil)
 		_, _ = h.Uninstall(cfg, "default", "name", false)
 		_, _ = h.Upgrade(cfg, "default", "name", false, "chart/ref", nil)
 		_ = h.Rollback(cfg, "default", "name", false)


### PR DESCRIPTION
This pull request introduces support for adding custom labels and annotations to Helm release manifests during installation. The main changes include updating the Helm release installation logic to accept and apply these metadata values, defining new constants for standardized label and annotation keys, and ensuring the new functionality is covered in tests.

**Helm release installation enhancements:**

* The `Install` method in both the `ReleaseRepo` interface (`internal/core/application_release.go`) and its implementation (`internal/data/kube/helm_release.go`) now accepts `labels` and `annotations` as additional parameters, allowing custom metadata to be injected into release manifests. [[1]](diffhunk://#diff-219906e466347b1e86889aba5646bedd7728884aea65b1ffd5f3e9d98faa6641L22-R22) [[2]](diffhunk://#diff-2f33fdda4f8dcb580161a379c509fbd771d53dd3d785d3c80d9cb6cf667ed705L64-R108)
* A new `postRenderer` type is introduced to apply the provided labels and annotations to all manifest nodes after rendering, using `kustomize/kyaml` for YAML manipulation.

**Standardization of metadata keys:**

* New constants for label and annotation keys are defined in `internal/core/const.go`, including `ApplicationReleaseLLMDModelNameLabel` and `ApplicationReleaseChartRefAnnotation`, to ensure consistent usage across the codebase.

**Release creation logic updates:**

* The `CreateRelease` method now constructs and passes the appropriate labels and annotations based on the release context, such as including the model name for specific chart references.

**Dependency management:**

* The `go.mod` file is updated to add a direct dependency on `sigs.k8s.io/kustomize/kyaml`, which is required for post-rendering manifest manipulation. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R51) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L246)

**Test coverage:**

* Unit tests for Helm release installation are updated to use the new method signature, ensuring the changes are properly tested. [[1]](diffhunk://#diff-5f2c7b380a882aced4efed20b96a8594c57180e6ad0ecd6374c23f40452a0c27L72-R72) [[2]](diffhunk://#diff-5f2c7b380a882aced4efed20b96a8594c57180e6ad0ecd6374c23f40452a0c27L90-R90) [[3]](diffhunk://#diff-5f2c7b380a882aced4efed20b96a8594c57180e6ad0ecd6374c23f40452a0c27L163-R163)