### PR TITLE
fix: correct typo & update label assignment

### DIFF
--- a/internal/core/application_release.go
+++ b/internal/core/application_release.go
@@ -50,7 +50,9 @@ func (uc *ApplicationUseCase) CreateRelease(ctx context.Context, uuid, facility,
 		ApplicationReleaseNameLabel: name,
 	}
 	if strings.Contains(chartRef, "llm-d-incubation/llm-d-modelservice") {
-		labels[ApplicationReleaseLLMDModelNameLabel] = valuesMap["modelArtifacts.name"]
+		if modelName, ok := values["modelArtifacts.name"].(string); ok {
+			labels[ApplicationReleaseLLMDModelNameLabel] = modelName
+		}
 	}
 
 	// annotations

--- a/internal/data/kube/helm_release.go
+++ b/internal/data/kube/helm_release.go
@@ -26,15 +26,15 @@ type postRenderer struct {
 	extraAnnotations map[string]string
 }
 
-func newPostRenderer(extraLabels, extraAnnotaions map[string]string) *postRenderer {
+func newPostRenderer(extraLabels, extraAnnotations map[string]string) *postRenderer {
 	return &postRenderer{
 		extraLabels:      extraLabels,
-		extraAnnotations: extraAnnotaions,
+		extraAnnotations: extraAnnotations,
 	}
 }
 
 func (p *postRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
-	if len(p.extraLabels) == 0 {
+	if len(p.extraLabels) == 0 && len(p.extraAnnotations) == 0 {
 		return renderedManifests, nil
 	}
 	nodes, err := kio.FromBytes(renderedManifests.Bytes())


### PR DESCRIPTION
This pull request introduces a minor fix to how labels and annotations are handled in application releases and Helm post-rendering. The changes improve type safety and ensure that extra annotations are correctly processed.

Improvements to label and annotation handling:

* Updated the assignment of the `ApplicationReleaseLLMDModelNameLabel` label to safely check the type of `modelArtifacts.name` before setting it, preventing potential runtime errors.
* Fixed a typo in the `newPostRenderer` function parameter (`extraAnnotaions` → `extraAnnotations`) and updated the logic to only run the post-renderer when either extra labels or extra annotations are present.