### PR TITLE
fix: standardize scope handling across platform to Use scope name instead of uuid

### DIFF
--- a/internal/data/juju/application_offers.go
+++ b/internal/data/juju/application_offers.go
@@ -22,7 +22,7 @@ func NewApplicationOffers(juju *Juju) core.FacilityOffersRepo {
 var _ core.FacilityOffersRepo = (*applicationOffers)(nil)
 
 func (r *applicationOffers) GetConsumeDetails(_ context.Context, url string) (params.ConsumeOfferDetails, error) {
-	conn, err := r.juju.connection("")
+	conn, err := r.juju.connection("controller")
 	if err != nil {
 		return params.ConsumeOfferDetails{}, err
 	}

--- a/internal/data/juju/juju.go
+++ b/internal/data/juju/juju.go
@@ -63,6 +63,10 @@ func (m *Juju) connection(scope string) (api.Connection, error) {
 }
 
 func (m *Juju) getModelUUID(scope string) (string, error) {
+	if scope == "controller" {
+		return "", nil
+	}
+
 	conn, err := m.newConnection("")
 	if err != nil {
 		return "", err

--- a/internal/data/juju/model.go
+++ b/internal/data/juju/model.go
@@ -26,7 +26,7 @@ func NewModel(juju *Juju) core.ScopeRepo {
 var _ core.ScopeRepo = (*model)(nil)
 
 func (r *model) List(_ context.Context) ([]core.Scope, error) {
-	conn, err := r.juju.connection("")
+	conn, err := r.juju.connection("controller")
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (r *model) List(_ context.Context) ([]core.Scope, error) {
 }
 
 func (r *model) Get(_ context.Context, name string) (*core.Scope, error) {
-	conn, err := r.juju.connection("")
+	conn, err := r.juju.connection("controller")
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (r *model) Get(_ context.Context, name string) (*core.Scope, error) {
 }
 
 func (r *model) Create(_ context.Context, name string) (*core.Scope, error) {
-	conn, err := r.juju.connection("")
+	conn, err := r.juju.connection("controller")
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/lib/components/applications/dashboard/overview/control-plane.svelte
+++ b/web/src/lib/components/applications/dashboard/overview/control-plane.svelte
@@ -26,7 +26,7 @@
 	);
 
 	async function fetch() {
-		facilityClient.listFacilities({ scopeUuid: scope.uuid }).then((response) => {
+		facilityClient.listFacilities({ scope: scope.name }).then((response) => {
 			facilities.set(response.facilities);
 		});
 	}

--- a/web/src/lib/components/applications/dashboard/overview/worker.svelte
+++ b/web/src/lib/components/applications/dashboard/overview/worker.svelte
@@ -24,7 +24,7 @@
 	const activeWorkerUnits = $derived(workerUnits.filter((unit) => unit.workloadStatus?.state === 'active') ?? []);
 
 	async function fetch() {
-		facilityClient.listFacilities({ scopeUuid: scope.uuid }).then((response) => {
+		facilityClient.listFacilities({ scope: scope.name }).then((response) => {
 			facilities.set(response.facilities);
 		});
 	}

--- a/web/src/lib/components/machines/dashboard/overview/node-proportion.svelte
+++ b/web/src/lib/components/machines/dashboard/overview/node-proportion.svelte
@@ -39,7 +39,7 @@
 	} satisfies Chart.ChartConfig;
 
 	async function fetch() {
-		machineClient.listMachines({ scopeUuid: scope.uuid }).then((response) => {
+		machineClient.listMachines({ scope: scope.name }).then((response) => {
 			machines.set(response.machines);
 		});
 	}

--- a/web/src/lib/components/machines/dashboard/overview/nodes.svelte
+++ b/web/src/lib/components/machines/dashboard/overview/nodes.svelte
@@ -60,7 +60,7 @@
 	} satisfies Chart.ChartConfig;
 
 	async function fetch() {
-		machineClient.listMachines({ scopeUuid: scope.uuid }).then((response) => {
+		machineClient.listMachines({ scope: scope.name }).then((response) => {
 			machines.set(response.machines);
 		});
 	}

--- a/web/src/lib/components/machines/dashboard/overview/storage.svelte
+++ b/web/src/lib/components/machines/dashboard/overview/storage.svelte
@@ -61,7 +61,7 @@
 				storageUsages = response.result[0]?.values;
 			});
 
-		machineClient.listMachines({ scopeUuid: scope.uuid }).then((response) => {
+		machineClient.listMachines({ scope: scope.name }).then((response) => {
 			machines.set(response.machines);
 		});
 	}


### PR DESCRIPTION
This pull request updates how scope is handled throughout both the backend and frontend, standardizing the use of scope name instead of scope UUID when making API calls and establishing connections. The main goal is to ensure consistency and correctness in how scope is referenced, especially when interacting with controllers and listing resources.

**Backend changes (Go):**

* Standardized connection initialization to use `"controller"` as the scope argument in `juju.connection` across `application_offers.go` and `model.go`, ensuring consistent controller-level operations. [[1]](diffhunk://#diff-f9c724c20af27f62a954b02d964409cbfd14dc25b2bf0cd05ac56f54e107cfd4L25-R25) [[2]](diffhunk://#diff-f708d3175e45f3e6f9d000d0d74a0183c905827c8bb61c190168174f7fbb0189L29-R29) [[3]](diffhunk://#diff-f708d3175e45f3e6f9d000d0d74a0183c905827c8bb61c190168174f7fbb0189L42-R42) [[4]](diffhunk://#diff-f708d3175e45f3e6f9d000d0d74a0183c905827c8bb61c190168174f7fbb0189L62-R62)
* Updated `getModelUUID` in `juju.go` to return an empty string for the `"controller"` scope, preventing unnecessary model lookups when operating at the controller level.

**Frontend changes (Svelte):**

* Changed all resource listing API calls (`listFacilities`, `listMachines`) to use `scope.name` instead of `scope.uuid`, aligning frontend requests with the updated backend expectations. This affects the following components:
  * `dashboard/overview/control-plane.svelte`
  * `dashboard/overview/worker.svelte`
  * `dashboard/overview/node-proportion.svelte`
  * `dashboard/overview/nodes.svelte`
  * `dashboard/overview/storage.svelte`